### PR TITLE
feat(s2): implement async RunPod client

### DIFF
--- a/auth/runpod_client.py
+++ b/auth/runpod_client.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import os
 from typing import Optional
 
-from gradio_client import Client
+try:
+    from gradio_client import Client  # type: ignore
+except Exception:  # pragma: no cover - optional dep
+
+    class Client:  # type: ignore
+        """Fallback client if gradio_client is unavailable."""
+
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover
+            raise ImportError("gradio_client is required")
 
 
 class RunPodClient:

--- a/runpod_client.py
+++ b/runpod_client.py
@@ -1,7 +1,34 @@
-"""Backward-compatible wrapper for RunPod client."""
+"""Asynchronous RunPod client with environment-backed configuration."""
 
-from gradio_client import Client
+from __future__ import annotations
 
-from auth.runpod_client import RunPodClient
+import asyncio
+from typing import Optional
+
+from auth.runpod_client import RunPodClient as _SyncRunPodClient, Client
+from config.environment import Environment
+
+
+class RunPodClient(_SyncRunPodClient):
+    """Async wrapper that defers to the synchronous client in a thread."""
+
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        *,
+        api_key: Optional[str] = None,
+        timeout: int = 300,
+    ) -> None:
+        env = Environment.load()
+        super().__init__(endpoint or env.runpod_endpoint, timeout=timeout)
+        self.api_key = api_key or env.runpod_api_key
+
+    async def transcribe(self, file_path: str, *, stream: bool = False) -> str:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: _SyncRunPodClient.transcribe(self, file_path, stream=stream),
+        )
+
 
 __all__ = ["RunPodClient", "Client"]

--- a/tests/clients/test_runpod_client.py
+++ b/tests/clients/test_runpod_client.py
@@ -2,11 +2,13 @@ import sys
 from pathlib import Path
 
 import pytest
+import asyncio
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 
 from auth.runpod_client import RunPodClient
+from runpod_client import RunPodClient as AsyncRunPodClient
 from config.environment import Environment
 
 
@@ -52,6 +54,20 @@ def test_transcribe_calls_predict(monkeypatch):
             {"stream": True, "api_name": "/predict"},
         )
     ]
+
+
+def test_async_transcribe(monkeypatch):
+    dummy = DummyClient("http://api")
+    monkeypatch.setattr(
+        "auth.runpod_client.Client", lambda endpoint, timeout=300: dummy
+    )
+    client = AsyncRunPodClient("http://api")
+
+    async def run() -> str:
+        return await client.transcribe("file.wav")
+
+    result = asyncio.run(run())
+    assert result == "dummy-result"
 
 
 def test_environment_load(monkeypatch):


### PR DESCRIPTION
## Summary
- add optional import stub for `gradio_client`
- add asynchronous `RunPodClient` wrapper with env defaults
- test async transcription behaviour

## Testing
- `ruff format auth/runpod_client.py runpod_client.py tests/clients/test_runpod_client.py`
- `ruff check auth/runpod_client.py runpod_client.py tests/clients/test_runpod_client.py`
- `pytest -k test_ -q`
- `pytest --cov=./ -k test_ -q`

------
https://chatgpt.com/codex/tasks/task_e_6847999de3d48327bb0b12fc2c712d1e