### PR TITLE
feat(s4): implement RSS monitor service

### DIFF
--- a/rss_monitor.py
+++ b/rss_monitor.py
@@ -1,0 +1,45 @@
+import asyncio
+import hashlib
+from typing import Optional
+
+import requests
+
+from rss_parser import RSSParser
+from core.queue_manager import QueueManager
+
+
+class RSSMonitor:
+    """Asynchronously poll an RSS feed and enqueue new content."""
+
+    def __init__(self, feed_url: str, *, interval: float = 60.0, queues: Optional[QueueManager] = None) -> None:
+        self.feed_url = feed_url
+        self.interval = interval
+        self.queues = queues or QueueManager()
+        self.parser = RSSParser()
+        self._seen: set[str] = set()
+
+    async def fetch_feed(self) -> str:
+        """Fetch the raw RSS feed XML asynchronously."""
+        return await asyncio.to_thread(lambda: requests.get(self.feed_url, timeout=10).text)
+
+    def _hash(self, url: str) -> str:
+        return hashlib.sha256(url.encode()).hexdigest()
+
+    async def poll_once(self) -> list[str]:
+        """Poll the RSS feed once and queue any new URLs."""
+        xml = await self.fetch_feed()
+        urls = self.parser.extract_audio_urls(xml)
+        new_urls = []
+        for url in urls:
+            h = self._hash(url)
+            if h not in self._seen:
+                self._seen.add(h)
+                await self.queues.discovery.put(url)
+                new_urls.append(url)
+        return new_urls
+
+    async def start(self) -> None:
+        """Continuously poll based on the configured interval."""
+        while True:
+            await self.poll_once()
+            await asyncio.sleep(self.interval)

--- a/tests/test_rss_monitor.py
+++ b/tests/test_rss_monitor.py
@@ -1,0 +1,40 @@
+import asyncio
+from rss_monitor import RSSMonitor
+
+
+def make_xml(urls: list[str]) -> str:
+    items = ''.join(f"<item><enclosure url='{u}'/></item>" for u in urls)
+    return f"<rss><channel>{items}</channel></rss>"
+
+
+def test_poll_once_enqueues_new_urls(monkeypatch):
+    xml = make_xml(["a.mp3", "b.mp3"])
+    monitor = RSSMonitor("http://feed")
+
+    async def dummy_fetch(self):
+        return xml
+
+    async def run():
+        monkeypatch.setattr(RSSMonitor, "fetch_feed", dummy_fetch)
+        await monitor.poll_once()
+        assert await monitor.queues.discovery.get() == "a.mp3"
+        assert await monitor.queues.discovery.get() == "b.mp3"
+
+    asyncio.run(run())
+
+
+def test_deduplication(monkeypatch):
+    xml = make_xml(["a.mp3"])  # same item every poll
+    monitor = RSSMonitor("http://feed")
+
+    async def dummy_fetch(self):
+        return xml
+
+    async def run():
+        monkeypatch.setattr(RSSMonitor, "fetch_feed", dummy_fetch)
+        await monitor.poll_once()
+        await monitor.poll_once()
+        assert monitor.queues.discovery.qsize() == 1
+        assert await monitor.queues.discovery.get() == "a.mp3"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add `RSSMonitor` for async polling and deduplication
- queue new RSS items in discovery queue
- test RSS monitor behavior and ensure deduplication

## Testing
- `pytest -k test_rss -q --cov=rss_monitor --cov=rss_parser --cov-report=term-missing`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68479ca8455083279b688dc9d8023289