### PR TITLE
feat(s6): implement audio downloader and validator

### DIFF
--- a/audio/__init__.py
+++ b/audio/__init__.py
@@ -1,0 +1,7 @@
+"""Audio processing utilities."""
+
+from .downloader import AudioDownloader
+from .validator import AudioValidator
+from .file_manager import TempFileManager
+
+__all__ = ["AudioDownloader", "AudioValidator", "TempFileManager"]

--- a/audio/downloader.py
+++ b/audio/downloader.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Iterable
+import requests
+
+
+class AudioDownloader:
+    """Asynchronously download audio files with concurrency limits."""
+
+    def __init__(self, concurrency: int = 3) -> None:
+        self.semaphore = asyncio.Semaphore(concurrency)
+
+    async def download(self, url: str, dest: Path) -> Path:
+        """Download a single file to the given destination."""
+        async with self.semaphore:
+            await asyncio.to_thread(self._download_sync, url, dest)
+            return dest
+
+    async def download_many(self, tasks: Iterable[tuple[str, Path]]) -> list[Path]:
+        """Download multiple files concurrently."""
+        coros = [self.download(url, path) for url, path in tasks]
+        return await asyncio.gather(*coros)
+
+    def _download_sync(self, url: str, dest: Path) -> None:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        resp = requests.get(url, stream=True, timeout=10)
+        resp.raise_for_status()
+        with open(dest, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)

--- a/audio/file_manager.py
+++ b/audio/file_manager.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import tempfile
+import uuid
+from pathlib import Path
+
+
+class TempFileManager:
+    """Manage temporary files for the pipeline."""
+
+    def __init__(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.files: list[Path] = []
+
+    def create(self, suffix: str = "") -> Path:
+        path = self.root / f"{uuid.uuid4().hex}{suffix}"
+        self.files.append(path)
+        return path
+
+    def cleanup(self) -> None:
+        self._tmp.cleanup()
+
+    def __enter__(self) -> "TempFileManager":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.cleanup()

--- a/audio/validator.py
+++ b/audio/validator.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+
+class AudioValidator:
+    """Validate audio files using ffprobe."""
+
+    async def validate(self, path: Path) -> Dict[str, Any]:
+        try:
+            data = await asyncio.to_thread(self._probe, path)
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - safety
+            raise ValueError("ffprobe failed") from exc
+        return data
+
+    def _probe(self, path: Path) -> Dict[str, Any]:
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_format",
+            "-of",
+            "json",
+            str(path),
+        ]
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        info = json.loads(result.stdout)
+        fmt = info.get("format", {})
+        return {
+            "format": fmt.get("format_name"),
+            "duration": float(fmt.get("duration", 0.0)),
+            "bitrate": int(fmt.get("bit_rate", 0)),
+        }

--- a/tests/test_audio_downloader.py
+++ b/tests/test_audio_downloader.py
@@ -1,0 +1,49 @@
+import asyncio
+import sys
+from pathlib import Path
+import time
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from audio import AudioDownloader  # noqa: E402
+from audio.file_manager import TempFileManager  # noqa: E402
+
+
+def test_audio_downloader_respects_concurrency(monkeypatch):
+    calls = []
+
+    def fake_get(url, stream=False, timeout=10):
+        calls.append(url)
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def iter_content(self, chunk_size=8192):
+                time.sleep(0.05)
+                yield b"data"
+
+        return Resp()
+
+    monkeypatch.setattr("audio.downloader.requests.get", fake_get)
+
+    async def run(limit):
+        with TempFileManager() as fm:
+            downloader = AudioDownloader(concurrency=limit)
+            p1 = fm.create(".mp3")
+            p2 = fm.create(".mp3")
+            start = time.perf_counter()
+            await asyncio.gather(
+                downloader.download("http://a", p1),
+                downloader.download("http://b", p2),
+            )
+            duration = time.perf_counter() - start
+            return duration, p1.read_bytes(), p2.read_bytes()
+
+    duration1, d1, d2 = asyncio.run(run(1))
+    duration2, _, _ = asyncio.run(run(2))
+
+    assert d1 == b"data"
+    assert d2 == b"data"
+    assert duration1 > duration2
+    assert calls == ["http://a", "http://b", "http://a", "http://b"]

--- a/tests/test_audio_file_manager.py
+++ b/tests/test_audio_file_manager.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from audio import TempFileManager  # noqa: E402
+
+
+def test_temp_file_manager_creates_and_cleans():
+    with TempFileManager() as fm:
+        path = fm.create(".tmp")
+        path.write_text("hi")
+        root = fm.root
+        assert path.exists()
+    assert not root.exists()

--- a/tests/test_audio_validator.py
+++ b/tests/test_audio_validator.py
@@ -1,0 +1,45 @@
+import asyncio
+import sys
+import json
+import subprocess
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from audio import AudioValidator  # noqa: E402
+
+
+def test_audio_validator_parses_metadata(monkeypatch, tmp_path):
+    fake_output = json.dumps({"format": {"format_name": "mp3", "duration": "1.23", "bit_rate": "64000"}})
+
+    class Result:
+        stdout = fake_output
+
+    def fake_run(*args, **kwargs):
+        return Result()
+
+    monkeypatch.setattr("audio.validator.subprocess.run", fake_run)
+
+    path = tmp_path / "a.mp3"
+    path.write_bytes(b"data")
+    validator = AudioValidator()
+    data = asyncio.run(validator.validate(path))
+
+    assert data["format"] == "mp3"
+    assert data["duration"] == 1.23
+    assert data["bitrate"] == 64000
+
+
+def test_audio_validator_raises_on_failure(monkeypatch, tmp_path):
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "ffprobe")
+
+    monkeypatch.setattr("audio.validator.subprocess.run", fake_run)
+
+    path = tmp_path / "a.mp3"
+    path.write_bytes(b"data")
+    validator = AudioValidator()
+
+    with pytest.raises(ValueError):
+        asyncio.run(validator.validate(path))


### PR DESCRIPTION
## Summary
- add audio processing utilities for download, validation, and temp management
- implement async audio downloader with concurrency limits
- integrate ffprobe-based audio validator
- manage temp files with context manager
- add tests for downloader, validator and file manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a0f485b08327a3c5b9a462d1c781