### PR TITLE
feat(s8): add audio chunking module

### DIFF
--- a/audio/__init__.py
+++ b/audio/__init__.py
@@ -3,5 +3,12 @@
 from .downloader import AudioDownloader
 from .validator import AudioValidator
 from .file_manager import TempFileManager
+from .chunker import AudioChunker, ChunkMetadata
 
-__all__ = ["AudioDownloader", "AudioValidator", "TempFileManager"]
+__all__ = [
+    "AudioDownloader",
+    "AudioValidator",
+    "TempFileManager",
+    "AudioChunker",
+    "ChunkMetadata",
+]

--- a/audio/chunker.py
+++ b/audio/chunker.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class ChunkMetadata:
+    index: int
+    start: float
+    end: float
+    path: Path
+    source: Path
+
+
+class AudioChunker:
+    """Simple ffmpeg-based audio chunker."""
+
+    def __init__(self, min_seconds: int = 300, max_seconds: int = 900) -> None:
+        self.min_seconds = min_seconds
+        self.max_seconds = max_seconds
+
+    async def chunk(self, source: Path, dest_dir: Path) -> List[ChunkMetadata]:
+        return await asyncio.to_thread(self._chunk_sync, source, dest_dir)
+
+    def _chunk_sync(self, source: Path, dest_dir: Path) -> List[ChunkMetadata]:
+        duration = self._duration(source)
+        chunk_size = max(self.min_seconds, min(self.max_seconds, 600))
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        chunks = []
+        start = 0.0
+        index = 0
+        while start < duration:
+            end = min(start + chunk_size, duration)
+            out = dest_dir / f"{source.stem}_chunk{index}{source.suffix}"
+            cmd = [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(source),
+                "-ss",
+                str(start),
+                "-t",
+                str(end - start),
+                "-acodec",
+                "copy",
+                str(out),
+            ]
+            subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            chunks.append(ChunkMetadata(index=index, start=start, end=end, path=out, source=source))
+            index += 1
+            start = end
+        return chunks
+
+    def _duration(self, path: Path) -> float:
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(path),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return float(result.stdout.strip() or 0.0)
+
+    async def reassemble(self, chunks: List[ChunkMetadata], output: Path) -> Path:
+        await asyncio.to_thread(self._reassemble_sync, chunks, output)
+        return output
+
+    def _reassemble_sync(self, chunks: List[ChunkMetadata], output: Path) -> None:
+        list_file = output.with_suffix(".txt")
+        with open(list_file, "w") as f:
+            for chunk in chunks:
+                f.write(f"file '{chunk.path}'\n")
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            str(list_file),
+            "-acodec",
+            "copy",
+            str(output),
+        ]
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        list_file.unlink(missing_ok=True)

--- a/core/workflow_orchestrator.py
+++ b/core/workflow_orchestrator.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Optional
+
 from .queue_manager import QueueManager
+from audio.chunker import AudioChunker
 
 
 class WorkflowOrchestrator:
     """Basic orchestrator that moves items through the queues."""
 
-    def __init__(self, queues: QueueManager | None = None) -> None:
+    def __init__(self, queues: QueueManager | None = None, chunker: Optional[AudioChunker] = None) -> None:
         self.queues = queues or QueueManager()
+        self.chunker = chunker
 
     async def process_once(self) -> None:
         """Move one item through all pipeline stages."""
         item = await self.queues.discovery.get()
+        if self.chunker and isinstance(item, str):
+            # treat the item as a path to an audio file
+            await self.chunker.chunk(Path(item), Path(Path(item).parent))
         await self.queues.processing.put(f"processed:{item}")
         item = await self.queues.processing.get()
         await self.queues.assembly.put(f"assembled:{item}")

--- a/tests/test_audio_chunker.py
+++ b/tests/test_audio_chunker.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from audio.chunker import AudioChunker, ChunkMetadata
+
+
+def test_audio_chunker_splits(monkeypatch, tmp_path):
+    src = tmp_path / "a.mp3"
+    src.write_bytes(b"data")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "ffprobe" in cmd[0]:
+            class R: stdout = "100"  # duration 100s
+            return R()
+
+    monkeypatch.setattr("audio.chunker.subprocess.run", fake_run)
+
+    chunker = AudioChunker(min_seconds=30, max_seconds=60)
+    chunks = asyncio.run(chunker.chunk(src, tmp_path))
+
+    assert len(chunks) == 2
+    assert isinstance(chunks[0], ChunkMetadata)
+    assert calls
+
+
+def test_audio_chunker_reassemble(monkeypatch, tmp_path):
+    out = tmp_path / "out.mp3"
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return types.SimpleNamespace()
+
+    monkeypatch.setattr("audio.chunker.subprocess.run", fake_run)
+
+    chunker = AudioChunker()
+    chunks = [
+        ChunkMetadata(0, 0, 1, tmp_path / "c1.mp3", tmp_path / "src.mp3"),
+        ChunkMetadata(1, 1, 2, tmp_path / "c2.mp3", tmp_path / "src.mp3"),
+    ]
+    asyncio.run(chunker.reassemble(chunks, out))
+
+    assert out.with_suffix(".txt") not in tmp_path.iterdir()
+    assert calls

--- a/tests/test_chunk_workflow_integration.py
+++ b/tests/test_chunk_workflow_integration.py
@@ -1,0 +1,35 @@
+import asyncio
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.queue_manager import QueueManager
+from core.workflow_orchestrator import WorkflowOrchestrator
+from audio.chunker import AudioChunker
+
+
+class DummyChunker(AudioChunker):
+    def __init__(self):
+        super().__init__()
+        self.called_with: list[Path] = []
+
+    async def chunk(self, source: Path, dest_dir: Path):
+        self.called_with.append(source)
+        return []
+
+
+def test_chunk_workflow_integration(monkeypatch, tmp_path):
+    qm = QueueManager()
+    chunker = DummyChunker()
+    orch = WorkflowOrchestrator(qm, chunker=chunker)
+
+    async def run():
+        await qm.discovery.put(str(tmp_path / "a.mp3"))
+        await orch.process_once()
+        return await qm.delivery.get()
+
+    result = asyncio.run(run())
+    assert result == f"delivered:assembled:processed:{tmp_path / 'a.mp3'}"
+    assert chunker.called_with


### PR DESCRIPTION
## Summary
- implement `AudioChunker` with ffmpeg-based splitting and reassembly
- expose `AudioChunker` via audio package
- integrate optional chunker into `WorkflowOrchestrator`
- add unit tests for chunking logic and orchestrator integration

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6847a346953c832793c21c8deaeb979f