### PR TITLE
feat(s9): integrate RunPod and transcript assembly

### DIFF
--- a/audio/downloader.py
+++ b/audio/downloader.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Tuple
 import requests
 
 
@@ -10,13 +10,37 @@ class AudioDownloader:
     """Asynchronously download audio files with concurrency limits."""
 
     def __init__(self, concurrency: int = 3) -> None:
+        self.concurrency = concurrency
         self.semaphore = asyncio.Semaphore(concurrency)
+        self._queue: asyncio.Queue[Tuple[str, Path, asyncio.Future[Path]]] = asyncio.Queue()
+        self._started = False
+        self._worker: asyncio.Task | None = None
+
+    async def _ensure_worker(self) -> None:
+        if not self._started:
+            self._started = True
+            self._worker = asyncio.create_task(self._worker_loop())
+
+    async def _worker_loop(self) -> None:
+        while True:
+            url, dest, fut = await self._queue.get()
+            asyncio.create_task(self._start_download(url, dest, fut))
+
+    async def _start_download(self, url: str, dest: Path, fut: asyncio.Future[Path]) -> None:
+        async with self.semaphore:
+            try:
+                await asyncio.to_thread(self._download_sync, url, dest)
+                fut.set_result(dest)
+            except Exception as exc:  # pragma: no cover - sanity
+                fut.set_exception(exc)
 
     async def download(self, url: str, dest: Path) -> Path:
         """Download a single file to the given destination."""
-        async with self.semaphore:
-            await asyncio.to_thread(self._download_sync, url, dest)
-            return dest
+        await self._ensure_worker()
+        loop = asyncio.get_event_loop()
+        fut: asyncio.Future[Path] = loop.create_future()
+        await self._queue.put((url, dest, fut))
+        return await fut
 
     async def download_many(self, tasks: Iterable[tuple[str, Path]]) -> list[Path]:
         """Download multiple files concurrently."""

--- a/core/transcript_assembler.py
+++ b/core/transcript_assembler.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict, Any
+
+
+@dataclass
+class TranscriptChunk:
+    """Data for a single transcribed chunk."""
+
+    index: int
+    start: float
+    end: float
+    text: str
+    word_timestamps: List[Dict[str, float]] | None = None
+
+
+class TranscriptAssembler:
+    """Reassemble ordered transcript chunks and adjust timestamps."""
+
+    def assemble(self, chunks: List[TranscriptChunk]) -> Dict[str, Any]:
+        ordered = sorted(chunks, key=lambda c: c.index)
+        text_parts: List[str] = []
+        words: List[Dict[str, float]] = []
+
+        for chunk in ordered:
+            text_parts.append(chunk.text)
+            for wt in chunk.word_timestamps or []:
+                words.append(
+                    {
+                        **wt,
+                        "start": wt["start"] + chunk.start,
+                        "end": wt["end"] + chunk.start,
+                    }
+                )
+
+        return {
+            "text": " ".join(t.strip() for t in text_parts).strip(),
+            "words": words,
+        }
+
+
+__all__ = ["TranscriptAssembler", "TranscriptChunk"]

--- a/core/workflow_orchestrator.py
+++ b/core/workflow_orchestrator.py
@@ -1,27 +1,88 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 from .queue_manager import QueueManager
 from audio.chunker import AudioChunker
+from audio.file_manager import TempFileManager
+from audio.downloader import AudioDownloader
+from audio.validator import AudioValidator
+from runpod_client import RunPodClient
+from .transcript_assembler import TranscriptAssembler, TranscriptChunk
 
 
 class WorkflowOrchestrator:
     """Basic orchestrator that moves items through the queues."""
 
-    def __init__(self, queues: QueueManager | None = None, chunker: Optional[AudioChunker] = None) -> None:
+    def __init__(
+        self,
+        queues: QueueManager | None = None,
+        *,
+        downloader: Optional[AudioDownloader] = None,
+        validator: Optional[AudioValidator] = None,
+        chunker: Optional[AudioChunker] = None,
+        transcriber: Optional[RunPodClient] = None,
+        assembler: Optional[TranscriptAssembler] = None,
+        file_manager: Optional[TempFileManager] = None,
+    ) -> None:
         self.queues = queues or QueueManager()
+        self.downloader = downloader
+        self.validator = validator
         self.chunker = chunker
+        self.transcriber = transcriber
+        self.assembler = assembler
+        self.file_manager = file_manager or TempFileManager()
 
     async def process_once(self) -> None:
         """Move one item through all pipeline stages."""
         item = await self.queues.discovery.get()
-        if self.chunker and isinstance(item, str):
-            # treat the item as a path to an audio file
-            await self.chunker.chunk(Path(item), Path(Path(item).parent))
-        await self.queues.processing.put(f"processed:{item}")
+
+        if not (self.transcriber and self.assembler):
+            if self.chunker and isinstance(item, (str, Path)):
+                path_obj = Path(item)
+                await self.chunker.chunk(path_obj, path_obj.parent)
+            await self.queues.processing.put(f"processed:{item}")
+            item = await self.queues.processing.get()
+            await self.queues.assembly.put(f"assembled:{item}")
+            item = await self.queues.assembly.get()
+            await self.queues.delivery.put(f"delivered:{item}")
+            return
+
+        # Optional downloader stage for URLs
+        if self.downloader and isinstance(item, str) and item.startswith("http"):
+            path = self.file_manager.create(".mp3")
+            item = await self.downloader.download(item, path)
+
+        await self.queues.processing.put(item)
         item = await self.queues.processing.get()
-        await self.queues.assembly.put(f"assembled:{item}")
+
+        # Validation and chunking
+        path_obj = Path(item) if isinstance(item, (str, Path)) else None
+        if self.validator and path_obj:
+            await self.validator.validate(path_obj)
+        chunks = []
+        if self.chunker and path_obj:
+            chunks = await self.chunker.chunk(path_obj, path_obj.parent)
+
+        await self.queues.assembly.put(chunks or item)
         item = await self.queues.assembly.get()
-        await self.queues.delivery.put(f"delivered:{item}")
+
+        # Transcription + assembly
+        if isinstance(item, list) and self.transcriber and self.assembler:
+            results: List[TranscriptChunk] = []
+            for ch in item:
+                text = await self.transcriber.transcribe(str(ch.path))
+                results.append(
+                    TranscriptChunk(
+                        index=ch.index,
+                        start=ch.start,
+                        end=ch.end,
+                        text=text,
+                        word_timestamps=[],
+                    )
+                )
+            assembled = self.assembler.assemble(results)
+            await self.queues.delivery.put(assembled)
+        else:
+            await self.queues.delivery.put(f"delivered:{item}")

--- a/runpod_client.py
+++ b/runpod_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Optional
 
+import os
 from auth.runpod_client import RunPodClient as _SyncRunPodClient, Client
 from config.environment import Environment
 
@@ -19,9 +20,16 @@ class RunPodClient(_SyncRunPodClient):
         api_key: Optional[str] = None,
         timeout: int = 300,
     ) -> None:
-        env = Environment.load()
-        super().__init__(endpoint or env.runpod_endpoint, timeout=timeout)
-        self.api_key = api_key or env.runpod_api_key
+        if endpoint is None:
+            env = Environment.load()
+            endpoint = env.runpod_endpoint
+            api_key = api_key or env.runpod_api_key
+        else:
+            if api_key is None:
+                api_key = os.getenv("RUNPOD_API_KEY")
+
+        super().__init__(endpoint, timeout=timeout)
+        self.api_key = api_key
 
     async def transcribe(self, file_path: str, *, stream: bool = False) -> str:
         loop = asyncio.get_event_loop()

--- a/tests/clients/test_runpod_client.py
+++ b/tests/clients/test_runpod_client.py
@@ -40,6 +40,16 @@ def test_init_from_env(monkeypatch):
     assert client.client is dummy
 
 
+def test_init_override_no_env(monkeypatch):
+    dummy = DummyClient("http://api")
+    monkeypatch.delenv("RUNPOD_ENDPOINT", raising=False)
+    monkeypatch.setattr(
+        "auth.runpod_client.Client", lambda endpoint, timeout=300: dummy
+    )
+    client = RunPodClient("http://api")
+    assert client.endpoint == "http://api"
+
+
 def test_transcribe_calls_predict(monkeypatch):
     dummy = DummyClient("http://api")
     monkeypatch.setattr(

--- a/tests/test_full_pipeline.py
+++ b/tests/test_full_pipeline.py
@@ -1,0 +1,58 @@
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.queue_manager import QueueManager
+from core.workflow_orchestrator import WorkflowOrchestrator
+from core.transcript_assembler import TranscriptAssembler, TranscriptChunk
+from audio.chunker import ChunkMetadata
+from audio.file_manager import TempFileManager
+
+
+class DummyDownloader:
+    async def download(self, url: str, dest: Path) -> Path:
+        dest.write_text("audio")
+        return dest
+
+
+class DummyValidator:
+    async def validate(self, path: Path):
+        return {"duration": 1.0}
+
+
+class DummyChunker:
+    async def chunk(self, source: Path, dest: Path):
+        return [
+            ChunkMetadata(0, 0.0, 1.0, dest / "c0.mp3", source),
+            ChunkMetadata(1, 1.0, 2.0, dest / "c1.mp3", source),
+        ]
+
+
+class DummyTranscriber:
+    async def transcribe(self, path: str, stream: bool = False) -> str:
+        return "hello" if "c0" in path else "world"
+
+
+def test_full_pipeline_integration(tmp_path):
+    qm = QueueManager()
+    fm = TempFileManager()
+    orch = WorkflowOrchestrator(
+        qm,
+        downloader=DummyDownloader(),
+        validator=DummyValidator(),
+        chunker=DummyChunker(),
+        transcriber=DummyTranscriber(),
+        assembler=TranscriptAssembler(),
+        file_manager=fm,
+    )
+
+    async def run():
+        await qm.discovery.put("http://audio")
+        await orch.process_once()
+        return await qm.delivery.get()
+
+    result = asyncio.run(run())
+    assert result["text"] == "hello world"
+

--- a/tests/test_transcript_assembler.py
+++ b/tests/test_transcript_assembler.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.transcript_assembler import TranscriptAssembler, TranscriptChunk
+
+
+def test_transcript_assembler_orders_and_adjusts():
+    chunks = [
+        TranscriptChunk(
+            index=1,
+            start=5.0,
+            end=10.0,
+            text="world",
+            word_timestamps=[{"word": "world", "start": 0.0, "end": 1.0}],
+        ),
+        TranscriptChunk(
+            index=0,
+            start=0.0,
+            end=5.0,
+            text="hello",
+            word_timestamps=[{"word": "hello", "start": 0.0, "end": 1.0}],
+        ),
+    ]
+    assembler = TranscriptAssembler()
+    result = assembler.assemble(chunks)
+
+    assert result["text"] == "hello world"
+    assert result["words"] == [
+        {"word": "hello", "start": 0.0, "end": 1.0},
+        {"word": "world", "start": 5.0, "end": 6.0},
+    ]


### PR DESCRIPTION
## Summary
- fix RunPod client env handling so endpoint param works without env vars
- implement `TranscriptAssembler` for merging chunk transcripts
- extend `WorkflowOrchestrator` with optional downloader/validator/transcriber
- update `AudioDownloader` with ordered concurrency workers
- add tests for new assembler, RunPod client, and full pipeline integration

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6847a571254c83279f1109a37c839fd4